### PR TITLE
Streamline UI and simplify export workflow

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,11 +11,14 @@ The MS Teams Live Captions Saver (SaveAs Fork) builds on the original extension,
 ## Current Enhancements
 - `saveAs` option → lets users choose where transcripts are saved instead of forcing the default Downloads folder.
 - Save behavior controls with optional custom download folder support.
+- Streamlined popup optimized for Microsoft Teams PWA with touch-friendly actions.
+- Lean export workflow focused on TXT and Markdown with simplified copy options.
+- Enhanced filename variables and timestamp preferences, including relative timers for meetings.
 
 ## Planned Enhancements
-- Streamlined UI for PWA users.
-- Lean export options (trim AI/analytics features for lightweight use).
-- Improved filename patterns and timestamp handling.
+- Quick filters for session history (search by meeting title or date).
+- Optional transcript trimming for long-running meetings.
+- Additional visual themes for light/dark PWA environments.
 
 ## Development Setup
 
@@ -46,25 +49,18 @@ You can still load the unpacked extension directly:
 
 # MS Teams Live Captions Saver Browser Extension v4.5
 
-The MS Teams Live Captions Saver is a powerful Chrome extension that captures, saves, and analyzes live captions from Microsoft Teams meetings. With advanced features like AI-powered summaries, speaker tracking, attendee monitoring, and automated exports, it's the perfect tool for meeting documentation and accessibility.
+The MS Teams Live Captions Saver is a streamlined Chrome extension that captures and exports live captions from Microsoft Teams meetings. This fork focuses on lightweight, PWA-friendly workflows so you can save transcripts quickly without extra overhead.
 
 ## Key Features
 
-### Core Functionality
-- **Real-time Caption Capture** - Automatically captures live captions during Teams meetings
-- **Multiple Export Formats** - Save as TXT, Markdown, JSON, YAML, DOC, or AI-optimized formats
-- **Speaker Identification & Aliasing** - Track who said what with customizable speaker names
-- **Attendee Tracking** - Monitor meeting participants with join/leave timestamps
-- **Auto-Save on Meeting End** - Never lose your transcripts with automatic saving
-
-### Advanced Features
-- **AI-Powered Templates** - 9 built-in meeting templates (Standup, Retrospective, Planning, etc.)
-- **AI Assistant Profiles** - Load ChatGPT, Claude, or Gemini prompts tuned for finding open tasks
-- **Custom AI Instructions** - Create and save your own AI analysis templates
-- **Meeting Analytics Dashboard** - View speaker participation, word counts, and statistics
-- **Live Transcript Viewer** - Search and filter transcripts in real-time
-- **Customizable Filename Patterns** - Use variables like {date}, {time}, {title}, {attendees}
-- **Multiple Timestamp Formats** - Choose between 12-hour, 24-hour, or relative timestamps
+- **Real-time Caption Capture** — Automatically captures live captions during Teams meetings.
+- **Lean Export Formats** — Save as TXT or Markdown with Save As support and custom sub-folders.
+- **Speaker Identification & Aliasing** — Track who said what with customizable speaker names.
+- **Optional Attendee Tracking** — Monitor meeting participants with join/leave timestamps.
+- **Auto-Save on Meeting End** — Never lose your transcripts with automatic saving.
+- **Custom Filename Patterns** — Use variables like `{date}`, `{time}`, `{datetime}`, `{title}`, `{format}`, `{attendees}`.
+- **Flexible Timestamp Formats** — Choose between 12-hour, 24-hour, or relative meeting timers.
+- **Session History & Viewer** — Reopen, export, or delete past meetings directly from the popup.
 
 ## Install from the Chrome Store
 
@@ -95,7 +91,7 @@ The extension popup provides:
 - **Quick export buttons** with dropdown format selection
 - **Speaker alias management** for correcting names
 - **Auto-save configuration** with customizable settings
-- **AI template selection** for intelligent summaries
+- **Lean settings** for timestamp style, auto-save behavior, and filename patterns
 
 ## Transcript Viewer
 
@@ -114,7 +110,7 @@ Click "View Transcript" to open the interactive viewer with:
 
 ![Advanced Settings](IMG/Extension%20Popup%202.png)
 
-*AI customization and meeting features configuration*
+*Lean meeting automation and timestamp controls*
 
 ### Meeting Features
 - **Auto-start Live Captions** - Automatically enables Teams captions when joining
@@ -122,20 +118,10 @@ Click "View Transcript" to open the interactive viewer with:
 - **Timestamp Format Options** - Customize time display format
 - **Filename Pattern Variables** - Create dynamic file names
 
-### AI Customization
-- **9 Built-in Templates**:
-  - Executive Summary
-  - Daily Standup
-  - Sprint Retrospective
-  - Sprint Planning
-  - Design Review
-  - Interview Notes
-  - All Hands Meeting
-  - One-on-One
-  - Brainstorming Session
-- **Custom Templates** - Save your own AI prompts for reuse
-- **AI Assistant Selector** - Swap between ChatGPT, Claude, Gemini, or a custom workflow prompt for task-focused analysis
-- **Quick Template Buttons** - One-click access to common analyses
+### Lean Controls
+- **Relative Timers** - Track how long a discussion has been running with zero-based timestamps.
+- **Save Behavior** - Choose between Save As prompts or background auto-save to preset folders.
+- **PWA-Friendly Layout** - Buttons sized for touch and narrow popup widths.
 
 ## Standalone Console Script
 
@@ -162,18 +148,9 @@ For environments where browser extensions cannot be installed:
 
 ### Standard Formats
 - **TXT** - Plain text with timestamps
-- **Markdown** - Formatted with speaker sections
-- **JSON** - Structured data with metadata
-- **YAML** - Human-readable structured format
-- **DOC** - Microsoft Word document
+- **Markdown** - Formatted with speaker sections ready for notes
 
-### AI-Optimized Format
-Includes special formatting and instructions for AI analysis:
-- Meeting context and metadata
-- Structured transcript for LLM processing
-- Template-specific prompts
-- Action item extraction
-- Decision tracking
+Lean exports honor the timestamp style you choose (12-hour, 24-hour, or relative) and support filename variables such as `{date}`, `{time}`, `{datetime}`, `{title}`, `{format}`, and `{attendees}`.
 
 ## Manual Installation (Developer Mode)
 

--- a/teams-captions-saver/popup.html
+++ b/teams-captions-saver/popup.html
@@ -6,57 +6,58 @@
     <style>
         body {
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-            background-color: #f4f4f4;
+            background-color: #ffffff;
             margin: 0;
-            padding: 15px 20px;
-            width: 400px;
+            padding: 16px;
+            width: 320px;
             box-sizing: border-box;
             display: flex;
             flex-direction: column;
-            align-items: center;
+            gap: 12px;
+            color: #1f1f1f;
         }
 
-        h2, p {
-            margin: 4px 0;
-            text-align: center;
+        h2 {
+            margin: 0;
+            font-size: 20px;
+            text-align: left;
         }
 
         .subtitle {
-            font-size: 14px;
-            font-style: italic;
-            font-weight: normal;
-            color: #555;
+            margin: 0;
+            font-size: 13px;
+            color: #5c5c5c;
         }
 
         .info-text {
             font-size: 12px;
-            color: #6c757d;
-            margin-top: 15px;
+            color: #5c5c5c;
+            margin: 0;
             line-height: 1.5;
         }
 
         .small-info-text {
-            font-size: 12px;
+            font-size: 11px;
             color: #6c757d;
             width: 100%;
             text-align: left;
-            margin-left: 2px;
+            margin: 4px 0 0 0;
         }
 
         #status-message {
-            font-weight: bold;
-            margin-top: 15px;
-            height: 20px;
+            font-weight: 600;
+            margin: 4px 0 0 0;
+            min-height: 20px;
         }
 
         #status-message a {
-            color: #17a2b8;
+            color: #0f6cbd;
             text-decoration: underline;
             transition: color 0.3s ease;
         }
 
         #status-message a:hover {
-            color: #138496;
+            color: #0b4f8a;
         }
 
         kbd {
@@ -76,8 +77,7 @@
             flex-direction: row;
             justify-content: center;
             width: 100%;
-            margin-top: 20px;
-            gap: 10px;
+            gap: 8px;
         }
         
         button, .split-button > button {
@@ -96,18 +96,18 @@
             opacity: 0.7;
         }
 
-        #copyButton, #copyDropdownButton { background-color: #007bff; }
-        #copyButton:not(:disabled):hover, #copyDropdownButton:not(:disabled):hover { background-color: #0069d9; }
-        
-        #saveButton, #saveDropdownButton { background-color: #28a745; }
-        #saveButton:not(:disabled):hover, #saveDropdownButton:not(:disabled):hover { background-color: #1e7e34; }
+        #copyButton, #copyDropdownButton { background-color: #0f6cbd; }
+        #copyButton:not(:disabled):hover, #copyDropdownButton:not(:disabled):hover { background-color: #0b4f8a; }
 
-        #viewButton { 
-            background-color: #17a2b8; 
-            flex-grow: 1; 
-            border-radius: 6px; 
+        #saveButton, #saveDropdownButton { background-color: #107c41; }
+        #saveButton:not(:disabled):hover, #saveDropdownButton:not(:disabled):hover { background-color: #0b6031; }
+
+        #viewButton {
+            background-color: #444791;
+            flex-grow: 1;
+            border-radius: 6px;
         }
-        #viewButton:not(:disabled):hover { background-color: #138496; }
+        #viewButton:not(:disabled):hover { background-color: #343170; }
 
         .split-button {
             position: relative;
@@ -157,26 +157,27 @@
         
         /* --- Settings Sections --- */
         .settings-container {
-            margin-top: 20px;
-            padding-top: 15px;
-            border-top: 1px solid #ddd;
+            margin-top: 8px;
+            padding: 12px;
+            border: 1px solid #e5e5e5;
+            border-radius: 8px;
             width: 100%;
             display: flex;
             flex-direction: column;
-            gap: 15px;
+            gap: 14px;
+            background-color: #fafafa;
         }
         .settings-header {
-            font-size: 18px;
+            font-size: 16px;
             font-weight: 600;
-            color: #333;
-            margin: 0 0 5px 0;
-            text-align: left;
+            color: #1f1f1f;
+            margin: 0;
         }
         .settings-subheader {
             font-size: 14px;
             font-weight: 600;
-            color: #555;
-            margin: 10px 0 5px 0;
+            color: #363636;
+            margin: 6px 0 4px 0;
             text-align: left;
             border-bottom: 1px solid #eee;
             padding-bottom: 5px;
@@ -189,8 +190,8 @@
             margin-top: 5px;
         }
         .setting-label {
-            font-size: 14px;
-            color: #333;
+            font-size: 13px;
+            color: #1f1f1f;
         }
         select#defaultSaveFormat {
             padding: 5px;
@@ -266,39 +267,6 @@
             text-align: left;
         }
 
-        /* --- AI Customization --- */
-        textarea#aiInstructions {
-            width: 100%;
-            box-sizing: border-box;
-            padding: 8px;
-            border-radius: 4px;
-            border: 1px solid #ccc;
-            font-family: inherit;
-            font-size: 13px;
-            resize: vertical;
-        }
-        .prompt-suggestion-container {
-            display: flex;
-            gap: 5px;
-            margin-top: 8px;
-            flex-wrap: wrap;
-        }
-        .prompt-button {
-            background-color: #e9ecef;
-            color: #495057;
-            border: 1px solid #dee2e6;
-            border-radius: 12px;
-            padding: 4px 10px;
-            font-size: 12px;
-            font-weight: 500;
-            cursor: pointer;
-            transition: background-color 0.2s ease, border-color 0.2s ease;
-        }
-        .prompt-button:hover {
-            background-color: #dee2e6;
-            border-color: #ced4da;
-        }
-        
         /* Session History Styles */
         .session-item {
             padding: 8px;
@@ -367,10 +335,10 @@
 </head>
 
 <body>
-    <h2>Teams Captions Saver v4.5</h2>
-    <p class="subtitle">For Microsoft Teams on the Web</p>
-    
-    <p id="manual-start-info" class="info-text">To begin, turn on live captions in your Teams meeting.</p>
+    <h2>Teams Captions Saver</h2>
+    <p class="subtitle">Optimized for Microsoft Teams PWA</p>
+
+    <p id="manual-start-info" class="info-text">Turn on live captions in your meeting to start capturing.</p>
 
     <p id="status-message">Checking status...</p>
 
@@ -379,8 +347,7 @@
             <button id="copyButton" class="split-button-main" disabled>Copy Transcript</button>
             <button id="copyDropdownButton" class="split-button-dropdown" disabled>▾</button>
             <div id="copyOptions" class="split-button-options">
-                <a href="#" data-copy-type="standard">Copy Standard Transcript</a>
-                <a href="#" data-copy-type="ai">Copy for AI Analysis</a>
+                <a href="#" data-copy-type="standard">Copy Transcript</a>
             </div>
         </div>
         <div class="split-button" id="save-container">
@@ -389,10 +356,6 @@
             <div id="saveOptions" class="split-button-options">
                 <a href="#" data-format="txt">Save as TXT (.txt)</a>
                 <a href="#" data-format="md">Save as Markdown (.md)</a>
-                <a href="#" data-format="doc">Save as Word (.doc)</a>
-                <a href="#" data-format="json">Save as JSON (.json)</a>
-                <div class="dropdown-divider"></div>
-                <a href="#" data-format="ai">Save for AI Analysis (.txt)</a>
             </div>
         </div>
     </div>
@@ -428,9 +391,6 @@
                 <select id="defaultSaveFormat">
                     <option value="txt">TXT</option>
                     <option value="md">Markdown</option>
-                    <option value="doc">Word</option>
-                    <option value="json">JSON</option>
-                    <option value="ai">AI Analysis</option>
                 </select>
             </div>
             <div class="setting-item">
@@ -485,61 +445,14 @@
                     <option value="relative">Relative (00:30:45)</option>
                 </select>
             </div>
-            <div class="setting-item">
+            <div class="setting-item" style="flex-direction: column; align-items: stretch; gap: 6px;">
                 <label for="filenamePattern" class="setting-label">Filename Pattern</label>
-                <input type="text" id="filenamePattern" 
-                    value="{date}_{title}_{format}" 
+                <input type="text" id="filenamePattern"
+                    value="{date}_{title}_{format}"
                     placeholder="{date}_{title}_{format}"
-                    style="width: 100%; padding: 5px; border-radius: 4px; border: 1px solid #ccc; font-size: 13px;">
-            </div>
-            <p class="small-info-text">Variables: {date}, {time}, {title}, {format}, {attendees}</p>
-        </div>
-
-        <div class="settings-group">
-            <p class="settings-subheader">AI Customization</p>
-            <div class="setting-item">
-                <label for="aiProvider" class="setting-label">Preferred AI Assistant</label>
-                <select id="aiProvider" style="padding: 5px; border-radius: 4px; border: 1px solid #ccc;">
-                    <option value="chatgpt">ChatGPT</option>
-                    <option value="claude">Claude</option>
-                    <option value="gemini">Gemini</option>
-                    <option value="custom">Custom Workflow</option>
-                </select>
-            </div>
-            <p class="small-info-text" id="aiProviderDescription">Each assistant loads a tailored prompt to surface open tasks and follow-ups.</p>
-            <label for="aiInstructions" class="setting-label" style="margin-bottom: 5px;">Custom AI Instructions</label>
-            <p class="small-info-text" style="margin: 0 0 8px 0;">This text is used for "Copy/Save for AI" actions.</p>
-            <textarea id="aiInstructions" rows="4" placeholder="Example: Summarize this transcript into key action items..."></textarea>
-            <div style="margin: 8px 0;">
-                <label for="meetingType" class="setting-label" style="font-size: 12px;">Meeting Type Templates:</label>
-                <div style="display: flex; gap: 5px; margin-bottom: 8px;">
-                    <select id="meetingType" style="flex: 1; padding: 5px; border-radius: 4px; border: 1px solid #ccc;">
-                        <option value="">-- Select Template --</option>
-                        <optgroup label="Built-in Templates">
-                            <option value="executive">Executive Summary</option>
-                            <option value="standup">Daily Standup</option>
-                            <option value="retrospective">Retrospective</option>
-                            <option value="planning">Sprint Planning</option>
-                            <option value="review">Design Review</option>
-                            <option value="interview">Interview</option>
-                            <option value="allhands">All Hands</option>
-                            <option value="1on1">One-on-One</option>
-                            <option value="brainstorm">Brainstorming</option>
-                        </optgroup>
-                        <optgroup label="Custom Templates" id="customTemplatesGroup">
-                        </optgroup>
-                    </select>
-                    <button id="deleteTemplateBtn" style="padding: 5px 10px; background: #dc3545; color: white; border: none; border-radius: 4px; cursor: pointer; display: none;" title="Delete selected custom template">🗑️</button>
-                </div>
-                <div style="display: flex; gap: 5px;">
-                    <input type="text" id="templateName" placeholder="Template name..." style="flex: 1; padding: 5px; border-radius: 4px; border: 1px solid #ccc; font-size: 13px;">
-                    <button id="saveTemplateBtn" style="padding: 5px 15px; background: #28a745; color: white; border: none; border-radius: 4px; cursor: pointer;" title="Save current instructions as template">Save Template</button>
-                </div>
-            </div>
-            <div class="prompt-suggestion-container">
-                <button class="prompt-button">Summarize</button>
-                <button class="prompt-button">List Action Items</button>
-                <button class="prompt-button">Find Decisions</button>
+                    style="width: 100%; padding: 6px; border-radius: 4px; border: 1px solid #ccc; font-size: 13px;">
+                <p class="small-info-text">Variables: {date}, {time}, {datetime}, {title}, {format}, {attendees}</p>
+                <p class="small-info-text" id="filenamePreview">Example:</p>
             </div>
         </div>
     </div>

--- a/teams-captions-saver/popup.js
+++ b/teams-captions-saver/popup.js
@@ -21,16 +21,8 @@ const UI_ELEMENTS = {
     autoOpenAttendeesToggle: document.getElementById('autoOpenAttendeesToggle'),
     timestampFormat: document.getElementById('timestampFormat'),
     filenamePattern: document.getElementById('filenamePattern'),
-    meetingType: document.getElementById('meetingType'),
-    templateName: document.getElementById('templateName'),
-    saveTemplateBtn: document.getElementById('saveTemplateBtn'),
-    deleteTemplateBtn: document.getElementById('deleteTemplateBtn'),
-    customTemplatesGroup: document.getElementById('customTemplatesGroup'),
-    aiProvider: document.getElementById('aiProvider'),
-    aiProviderDescription: document.getElementById('aiProviderDescription'),
-    aiInstructions: document.getElementById('aiInstructions'),
+    filenamePreview: document.getElementById('filenamePreview'),
     speakerAliasList: document.getElementById('speaker-alias-list'),
-    promptButtons: document.querySelectorAll('.prompt-button'),
     // Session History Elements
     sessionHistory: document.getElementById('sessionHistory'),
     historyButton: document.getElementById('historyButton'),
@@ -38,43 +30,7 @@ const UI_ELEMENTS = {
 };
 
 
-const MEETING_TYPE_PROMPTS = {
-    "executive": "You are an executive assistant preparing a comprehensive meeting brief. Analyze this transcript and create a structured summary with:\n\n## Executive Summary\nProvide a 2-3 sentence overview of the meeting's purpose and outcome.\n\n## Key Decisions Made\nList each decision with:\n- The decision itself\n- Who made it\n- Impact/rationale\n- Timeline if mentioned\n\n## Action Items & Owners\nFormat as a table:\n| Owner | Action | Due Date | Priority |\n\n## Critical Discussion Points\n- Highlight 3-5 most important topics discussed\n- Include any concerns or risks raised\n\n## Follow-up Required\nList items needing attention from leadership\n\n## Metrics & KPIs Mentioned\nExtract any numbers, targets, or measurements discussed\n\nBe concise but thorough. Focus on what executives need to know and act upon.",
-    "standup": "You are a scrum master analyzing this daily standup. Create a comprehensive summary with:\n\n## Team Status Overview\nOne-line health check of the team's progress\n\n## Individual Updates\nFor each team member, capture:\n- ✅ Completed yesterday\n- 🎯 Working on today\n- 🚧 Blockers/impediments\n\n## Blocked Items Requiring Attention\nPrioritize by impact on sprint goals\n\n## Action Items\n- Include who will help resolve blockers\n- Note any meetings needed\n\n## Sprint Health Indicators\n- Are we on track for sprint goals?\n- Any risks to delivery?\n\nHighlight patterns across multiple team members (e.g., common blockers).",
-    "retrospective": "You are an agile coach facilitating continuous improvement. Analyze this retrospective and produce:\n\n## Sprint Sentiment\nOverall team morale and satisfaction (based on tone and feedback)\n\n## What Went Well\n- Group by themes (e.g., Process, Communication, Technical)\n- Note frequency if mentioned multiple times\n- Identify practices to continue\n\n## What Could Be Improved\n- Categorize by impact (High/Medium/Low)\n- Include root causes if discussed\n- Link related issues\n\n## Action Items (SMART format)\nFor each action:\n- Specific action to take\n- Owner(s)\n- Success criteria\n- Target completion date\n- Expected impact\n\n## Trends from Previous Retros\nIdentify recurring themes or unresolved issues\n\n## Team Dynamics Observations\nNote participation levels and any team health indicators",
-    "planning": "You are a product manager optimizing sprint planning. Extract and organize:\n\n## Sprint Goal\nClear, measurable objective for this sprint\n\n## Capacity Planning\n- Team availability (holidays, meetings)\n- Velocity comparison to previous sprints\n- Risk buffer included?\n\n## Committed User Stories\n| Story ID | Title | Story Points | Assignee | Acceptance Criteria Met? |\n\n## Technical Dependencies\n- Internal dependencies between stories\n- External team dependencies\n- Blocker mitigation plans\n\n## Risks & Mitigation\n- Identified risks to sprint success\n- Mitigation strategies discussed\n\n## Definition of Done Reminders\nAny special criteria for this sprint\n\n## Parking Lot\nItems discussed but deferred to next sprint\n\nCalculate total story points and flag if over/under capacity.",
-    "review": "You are a senior architect conducting a thorough design review. Document:\n\n## Design Overview\nBrief description of what was reviewed\n\n## Architectural Decisions\nFor each major decision:\n- Decision made\n- Alternatives considered\n- Trade-offs accepted\n- Technical rationale\n\n## Concerns & Risks Identified\nCategorize by:\n- 🔴 Critical (blocks implementation)\n- 🟡 Important (needs resolution soon)\n- 🟢 Minor (can be addressed later)\n\n## Approved Changes\n- What was approved\n- Conditions/requirements\n- Impact on timeline\n\n## Technical Debt Acknowledged\n- What debt was accepted\n- Plan to address it\n\n## Follow-up Actions\n| Action | Owner | Due Date | Required For |\n\n## Compliance & Standards\nNote any deviations from standards and justifications\n\n## Performance Considerations\nAny performance impacts discussed",
-    "interview": "You are a hiring manager evaluating candidates objectively. Structure your assessment as:\n\n## Candidate Overview\n- Role interviewed for\n- Interview round/type\n- Interviewers present\n\n## Technical Competencies Demonstrated\nRate each skill discussed:\n- Skill: [Strong/Adequate/Needs Development/Not Assessed]\n- Evidence from conversation\n\n## Behavioral Indicators\nUsing STAR format when possible:\n- Situation described\n- Actions taken\n- Results achieved\n- Competency demonstrated\n\n## Cultural Fit Observations\n- Alignment with company values\n- Team collaboration potential\n- Communication style\n\n## Red Flags or Concerns\n- Be specific and objective\n- Quote relevant statements\n\n## Strengths Highlighted\n- Unique value propositions\n- Standout moments\n\n## Questions from Candidate\n- What they asked about\n- Indicates interest/research level\n\n## Recommended Next Steps\n- Clear hire/no-hire recommendation\n- If proceeding, what to explore further\n- If not, specific gaps to document",
-    "allhands": "You are a communications director ensuring company-wide alignment. Create a digest with:\n\n## Meeting Headline\nOne impactful sentence summarizing the main message\n\n## Leadership Messages\n- Key points from each executive\n- Strategic priorities emphasized\n- Cultural messages reinforced\n\n## Company Metrics Shared\n| Metric | Current | Target | Trend |\n\n## Major Announcements\nFor each announcement:\n- What's changing/new\n- Why it matters\n- Timeline\n- Impact on teams\n\n## Recognition & Celebrations\n- Teams/individuals recognized\n- Achievements celebrated\n\n## Q&A Highlights\n- Most important questions asked\n- Leadership responses\n- Concerns addressed\n\n## Action Items by Department\nWhat each team needs to do differently\n\n## Resources Mentioned\n- Links, documents, or tools referenced\n\n## Next All-Hands Preview\nTopics to be covered next time",
-    "1on1": "You are a people manager focused on employee development. Document this 1:1 with:\n\n## Meeting Context\n- Manager and direct report names\n- Recurring or special 1:1?\n\n## Employee Well-being Check\n- Overall morale/satisfaction\n- Work-life balance indicators\n- Any personal concerns affecting work\n\n## Performance Discussion\n- Progress on current goals\n- Achievements to celebrate\n- Areas for improvement\n- Specific feedback exchanged\n\n## Career Development\n- Growth aspirations discussed\n- Skills to develop\n- Opportunities identified\n- Training/mentoring needs\n\n## Challenges & Support Needed\n- Current obstacles\n- Resources requested\n- Manager commitments to help\n\n## Action Items\n| Who | What | By When |\n\n## Topics for Next 1:1\n- Follow-ups needed\n- Topics parked for later\n\n## Manager Notes (Confidential)\n- Performance trends\n- Development opportunities\n- Team dynamics observations\n\nMaintain professional tone while capturing coaching moments.",
-    "brainstorm": "You are an innovation strategist maximizing creative output. Organize this session into:\n\n## Session Objective\nWhat problem were we trying to solve?\n\n## Ideas Generated (Grouped by Theme)\nOrganize ideas into logical categories:\n\n### Category 1\n- Idea (contributor)\n- Build on this: [related ideas]\n\n### Category 2\n- Continue pattern...\n\n## Top Ideas by Engagement\nList 5-7 ideas that generated most discussion/excitement:\n1. Idea - Why it resonated\n2. Continue...\n\n## Feasibility Quick Assessment\n| Idea | Impact | Effort | Priority |\n| --- | --- | --- | --- |\n| Top ideas... | High/Med/Low | High/Med/Low | 1-5 |\n\n## Wild Cards\nUnconventional ideas worth noting (even if not practical)\n\n## Next Steps\n- Which ideas move to validation?\n- Who owns follow-up?\n- Timeline for decisions\n\n## Parking Lot\nGood ideas outside current scope\n\n## Session Effectiveness\n- Participation level\n- Diversity of ideas\n- Did we meet objective?\n\nCapture the energy and creativity while maintaining actionable output."
-};
-
-const AI_TOOL_PROFILES = {
-    chatgpt: {
-        name: 'ChatGPT',
-        description: 'Optimized for ChatGPT with action-item tables and timestamp callouts.',
-        prompt: `You are ChatGPT acting as a project coordinator analyzing a Microsoft Teams meeting transcript. Focus on surfacing open tasks, owners, due dates, blockers, and unresolved questions. Produce Markdown with the following sections:\n\n## Quick Context\n- Two bullet points summarizing the meeting purpose and current status.\n\n## Open Tasks & Owners\nCreate a table with columns: Task | Owner | Due Date | Status/Notes. Use "Unassigned" or "TBD" when details are missing. Reference timestamps in parentheses when helpful.\n\n## Blockers & Risks\nBullet list of anything preventing progress or requiring escalation. Note the speaker and timestamp if available.\n\n## Follow-ups & Decisions\nBullet list of decisions made and follow-up questions that remain. Pair each item with the responsible owner.\n\n## Next Steps Summary\nProvide 2-3 bullets describing the immediate next actions.\n\nKeep the tone concise and action-oriented.`,
-    },
-    claude: {
-        name: 'Claude',
-        description: 'Great for narrative briefings that highlight commitments and unanswered questions.',
-        prompt: `You are Claude from Anthropic serving as a chief of staff reviewing a Microsoft Teams meeting transcript. Identify concrete commitments, outstanding requests, and anything that needs clarification. Return Markdown with:\n\n## Meeting Snapshot\n- One sentence on the meeting goal.\n- One sentence on the overall outcome.\n\n## Action Register\nTable columns: Owner | Commitment | Due Date/Timing | Notes. Highlight blockers or clarification needed in Notes. Use "TBD" when timing is unknown.\n\n## Pending Questions\nBullet list of unanswered questions or decisions that still need input. Include who should respond.\n\n## Risks & Dependencies\nBullet list of risks, dependencies, or cross-team impacts that could affect the tasks.\n\n## Recommended Follow-ups\nNumbered list of what should happen next and who should drive it.\n\nKeep language empathetic but direct, and call out when ownership is unclear.`,
-    },
-    gemini: {
-        name: 'Gemini',
-        description: 'Structured for Google Gemini with emphasis on confidence levels and checkpoints.',
-        prompt: `You are Google Gemini acting as a delivery tracker for the following Microsoft Teams transcript. Extract the work that remains and what needs clarification. Respond in Markdown with:\n\n## Key Themes\nProvide three bullets capturing the dominant topics.\n\n## Open Work Items\nTable columns: Work Item | Owner | Target Date | Confidence (High/Med/Low) | Notes. Mark missing information as "TBD" and mention relevant timestamps.\n\n## Open Questions & Clarifications\nBullet list of questions the team still needs answered. Suggest the most relevant owner for each.\n\n## Stakeholder Promises\nBullet list of commitments made to customers or stakeholders, including who promised and any dates.\n\n## Next Checkpoints\nBullet list of upcoming milestones, reviews, or follow-up meetings that should be scheduled.`,
-    },
-    custom: {
-        name: 'Custom Workflow',
-        description: 'Start from a blank slate and craft your own instructions for AI analysis.',
-        prompt: '',
-    }
-};
-
 let currentDefaultFormat = 'txt';
-let currentAiProvider = 'chatgpt';
 
 // --- Error Handling ---
 function safeExecute(fn, context = '', fallback = null) {
@@ -99,7 +55,7 @@ async function getActiveTeamsTab() {
     return teamsTab || null;
 }
 
-async function formatTranscript(transcript, aliases = {}, type = 'standard') {
+async function formatTranscript(transcript, aliases = {}) {
     if (!Array.isArray(transcript)) {
         return '';
     }
@@ -109,22 +65,7 @@ async function formatTranscript(transcript, aliases = {}, type = 'standard') {
         Name: aliases[entry.Name] || entry.Name
     }));
 
-    if (type === 'ai') {
-        const { aiInstructions: instructions } = await chrome.storage.sync.get('aiInstructions');
-        const transcriptText = processed.map(entry => `[${entry.Time}] ${entry.Name}: ${entry.Text}`).join('\n\n');
-        return instructions ? `${instructions}\n\n---\n\n${transcriptText}` : transcriptText;
-    }
-
     return processed.map(entry => `[${entry.Time}] ${entry.Name}: ${entry.Text}`).join('\n');
-}
-
-function updateAiProviderDescription(providerKey) {
-    if (!UI_ELEMENTS.aiProviderDescription) {
-        return;
-    }
-
-    const profile = AI_TOOL_PROFILES[providerKey];
-    UI_ELEMENTS.aiProviderDescription.textContent = profile?.description || 'Create your own instructions for AI processing.';
 }
 
 // --- UI Update Functions ---
@@ -181,7 +122,7 @@ function updateButtonStates(hasData) {
 }
 
 function updateSaveButtonText(format) {
-    UI_ELEMENTS.saveButton.textContent = format === 'ai' ? 'Save for AI' : `Save as ${format.toUpperCase()}`;
+    UI_ELEMENTS.saveButton.textContent = `Save as ${format.toUpperCase()}`;
 }
 
 function updateSaveLocationVisibility(type) {
@@ -195,6 +136,35 @@ function updateSaveLocationVisibility(type) {
     if (UI_ELEMENTS.saveLocationInput) {
         UI_ELEMENTS.saveLocationInput.disabled = !showCustom;
     }
+}
+
+function updateFilenamePreview() {
+    if (!UI_ELEMENTS.filenamePreview || !UI_ELEMENTS.filenamePattern) {
+        return;
+    }
+
+    const pattern = UI_ELEMENTS.filenamePattern.value || '{date}_{title}_{format}';
+    const now = new Date();
+    const dateStr = now.toISOString().split('T')[0];
+    const timeStr = now.toTimeString().split(' ')[0].replace(/:/g, '-');
+    const replacements = {
+        '{date}': dateStr,
+        '{time}': timeStr,
+        '{datetime}': `${dateStr}_${timeStr}`,
+        '{title}': 'Weekly Sync',
+        '{format}': currentDefaultFormat,
+        '{attendees}': '5_attendees'
+    };
+
+    let preview = pattern;
+    for (const [token, value] of Object.entries(replacements)) {
+        preview = preview.replace(new RegExp(token.replace(/[{}]/g, '\\$&'), 'g'), value);
+    }
+
+    preview = preview.replace(/__+/g, '_').replace(/_+$/, '');
+
+    const exampleName = preview || 'transcript';
+    UI_ELEMENTS.filenamePreview.textContent = `Example: ${exampleName}.${currentDefaultFormat}`;
 }
 
 async function renderSpeakerAliases(tab) {
@@ -224,91 +194,11 @@ async function renderSpeakerAliases(tab) {
     }
 }
 
-// --- Template Management ---
-async function loadCustomTemplates() {
-    const { customTemplates = {} } = await chrome.storage.sync.get('customTemplates');
-    
-    // Clear existing custom templates
-    UI_ELEMENTS.customTemplatesGroup.innerHTML = '';
-    
-    // Add custom templates to dropdown
-    Object.entries(customTemplates).forEach(([id, template]) => {
-        const option = document.createElement('option');
-        option.value = `custom_${id}`;
-        option.textContent = template.name;
-        UI_ELEMENTS.customTemplatesGroup.appendChild(option);
-    });
-    
-    // Show/hide custom templates optgroup
-    UI_ELEMENTS.customTemplatesGroup.style.display = 
-        Object.keys(customTemplates).length > 0 ? 'block' : 'none';
-}
-
-async function saveCustomTemplate(name, instructions) {
-    if (!name.trim() || !instructions.trim()) {
-        alert('Please enter both a template name and instructions.');
-        return;
-    }
-    
-    const { customTemplates = {} } = await chrome.storage.sync.get('customTemplates');
-    
-    // Generate unique ID
-    const id = Date.now().toString();
-    
-    // Add new template
-    customTemplates[id] = {
-        name: name.trim(),
-        instructions: instructions.trim(),
-        createdAt: new Date().toISOString()
-    };
-    
-    // Save to storage
-    await chrome.storage.sync.set({ customTemplates });
-    
-    // Reload templates
-    await loadCustomTemplates();
-    
-    // Clear template name input
-    UI_ELEMENTS.templateName.value = '';
-    
-    // Select the newly created template
-    UI_ELEMENTS.meetingType.value = `custom_${id}`;
-    
-    alert('Template saved successfully!');
-}
-
-async function deleteCustomTemplate(templateId) {
-    if (!confirm('Are you sure you want to delete this custom template?')) {
-        return;
-    }
-    
-    const { customTemplates = {} } = await chrome.storage.sync.get('customTemplates');
-    
-    // Remove the custom_ prefix to get the actual ID
-    const id = templateId.replace('custom_', '');
-    
-    delete customTemplates[id];
-    
-    // Save to storage
-    await chrome.storage.sync.set({ customTemplates });
-    
-    // Reload templates
-    await loadCustomTemplates();
-    
-    // Reset selection
-    UI_ELEMENTS.meetingType.value = '';
-    UI_ELEMENTS.deleteTemplateBtn.style.display = 'none';
-    
-    alert('Template deleted successfully!');
-}
-
 // --- Settings Management ---
 async function loadSettings() {
     const settings = await chrome.storage.sync.get([
         'autoEnableCaptions',
         'autoSaveOnEnd',
-        'aiInstructions',
-        'aiProvider',
         'defaultSaveFormat',
         'saveAsType',
         'saveLocation',
@@ -329,26 +219,16 @@ async function loadSettings() {
     }
     UI_ELEMENTS.timestampFormat.value = settings.timestampFormat || '12hr';
     UI_ELEMENTS.filenamePattern.value = settings.filenamePattern || '{date}_{title}_{format}';
-    currentAiProvider = settings.aiProvider || 'chatgpt';
-    if (UI_ELEMENTS.aiProvider) {
-        UI_ELEMENTS.aiProvider.value = currentAiProvider;
-    }
-    updateAiProviderDescription(currentAiProvider);
-
-    if (settings.aiInstructions) {
-        UI_ELEMENTS.aiInstructions.value = settings.aiInstructions;
-    } else {
-        const preset = AI_TOOL_PROFILES[currentAiProvider];
-        UI_ELEMENTS.aiInstructions.value = preset?.prompt || '';
-        if (preset?.prompt) {
-            await chrome.storage.sync.set({ aiInstructions: preset.prompt });
-        }
-    }
     UI_ELEMENTS.manualStartInfo.style.display = settings.autoEnableCaptions ? 'none' : 'block';
 
+    const allowedFormats = ['txt', 'md'];
     currentDefaultFormat = settings.defaultSaveFormat || 'txt';
+    if (!allowedFormats.includes(currentDefaultFormat)) {
+        currentDefaultFormat = 'txt';
+    }
     UI_ELEMENTS.defaultSaveFormatSelect.value = currentDefaultFormat;
     updateSaveButtonText(currentDefaultFormat);
+    updateFilenamePreview();
 
     if (UI_ELEMENTS.saveAsTypeSelect) {
         const saveAsType = settings.saveAsType || 'prompt';
@@ -363,11 +243,11 @@ async function loadSettings() {
 
 // --- Event Handling ---
 function setupEventListeners() {
-    // Settings Listeners
     UI_ELEMENTS.defaultSaveFormatSelect.addEventListener('change', (e) => {
         currentDefaultFormat = e.target.value;
         chrome.storage.sync.set({ defaultSaveFormat: currentDefaultFormat });
         updateSaveButtonText(currentDefaultFormat);
+        updateFilenamePreview();
     });
 
     if (UI_ELEMENTS.saveAsTypeSelect) {
@@ -384,29 +264,8 @@ function setupEventListeners() {
         });
     }
 
-    if (UI_ELEMENTS.aiProvider) {
-        UI_ELEMENTS.aiProvider.addEventListener('change', async (e) => {
-            const selectedProvider = e.target.value;
-            const previousProvider = currentAiProvider;
-            currentAiProvider = selectedProvider;
-            await chrome.storage.sync.set({ aiProvider: selectedProvider });
-            updateAiProviderDescription(selectedProvider);
-
-            const currentText = UI_ELEMENTS.aiInstructions.value.trim();
-            const previousPreset = AI_TOOL_PROFILES[previousProvider]?.prompt?.trim() || '';
-            const shouldApplyPreset = currentText.length === 0 || currentText === previousPreset;
-            const preset = AI_TOOL_PROFILES[selectedProvider];
-
-            if (shouldApplyPreset) {
-                UI_ELEMENTS.aiInstructions.value = preset?.prompt || '';
-                UI_ELEMENTS.aiInstructions.dispatchEvent(new Event('change'));
-            }
-        });
-    }
-
     UI_ELEMENTS.trackCaptionsToggle.addEventListener('change', (e) => {
         chrome.storage.sync.set({ trackCaptions: e.target.checked });
-        // Disable auto-enable captions if caption tracking is disabled
         if (!e.target.checked) {
             UI_ELEMENTS.autoEnableCaptionsToggle.checked = false;
             UI_ELEMENTS.autoEnableCaptionsToggle.disabled = true;
@@ -415,7 +274,7 @@ function setupEventListeners() {
             UI_ELEMENTS.autoEnableCaptionsToggle.disabled = false;
         }
     });
-    
+
     UI_ELEMENTS.autoEnableCaptionsToggle.addEventListener('change', (e) => {
         chrome.storage.sync.set({ autoEnableCaptions: e.target.checked });
         UI_ELEMENTS.manualStartInfo.style.display = e.target.checked ? 'none' : 'block';
@@ -427,7 +286,6 @@ function setupEventListeners() {
 
     UI_ELEMENTS.trackAttendeesToggle.addEventListener('change', (e) => {
         chrome.storage.sync.set({ trackAttendees: e.target.checked });
-        // Disable auto-open if tracking is disabled
         if (UI_ELEMENTS.autoOpenAttendeesToggle) {
             if (!e.target.checked) {
                 UI_ELEMENTS.autoOpenAttendeesToggle.checked = false;
@@ -438,14 +296,13 @@ function setupEventListeners() {
             }
         }
     });
-    
+
     if (UI_ELEMENTS.autoOpenAttendeesToggle) {
         UI_ELEMENTS.autoOpenAttendeesToggle.addEventListener('change', (e) => {
             chrome.storage.sync.set({ autoOpenAttendees: e.target.checked });
         });
     }
-    
-    // Initialize auto-enable captions toggle state based on track captions
+
     if (UI_ELEMENTS.trackCaptionsToggle) {
         UI_ELEMENTS.autoEnableCaptionsToggle.disabled = !UI_ELEMENTS.trackCaptionsToggle.checked;
     }
@@ -456,55 +313,7 @@ function setupEventListeners() {
 
     UI_ELEMENTS.filenamePattern.addEventListener('input', (e) => {
         chrome.storage.sync.set({ filenamePattern: e.target.value });
-    });
-
-    UI_ELEMENTS.meetingType.addEventListener('change', async (e) => {
-        const value = e.target.value;
-        
-        // Show/hide delete button for custom templates
-        UI_ELEMENTS.deleteTemplateBtn.style.display = 
-            value.startsWith('custom_') ? 'inline-block' : 'none';
-        
-        if (value) {
-            if (value.startsWith('custom_')) {
-                // Load custom template
-                const { customTemplates = {} } = await chrome.storage.sync.get('customTemplates');
-                const id = value.replace('custom_', '');
-                if (customTemplates[id]) {
-                    UI_ELEMENTS.aiInstructions.value = customTemplates[id].instructions;
-                    UI_ELEMENTS.aiInstructions.dispatchEvent(new Event('change'));
-                }
-            } else if (MEETING_TYPE_PROMPTS[value]) {
-                // Load built-in template
-                UI_ELEMENTS.aiInstructions.value = MEETING_TYPE_PROMPTS[value];
-                UI_ELEMENTS.aiInstructions.dispatchEvent(new Event('change'));
-            }
-        }
-    });
-    
-    UI_ELEMENTS.saveTemplateBtn.addEventListener('click', () => {
-        const name = UI_ELEMENTS.templateName.value;
-        const instructions = UI_ELEMENTS.aiInstructions.value;
-        saveCustomTemplate(name, instructions);
-    });
-    
-    UI_ELEMENTS.templateName.addEventListener('keypress', (e) => {
-        if (e.key === 'Enter') {
-            const name = UI_ELEMENTS.templateName.value;
-            const instructions = UI_ELEMENTS.aiInstructions.value;
-            saveCustomTemplate(name, instructions);
-        }
-    });
-    
-    UI_ELEMENTS.deleteTemplateBtn.addEventListener('click', () => {
-        const selectedValue = UI_ELEMENTS.meetingType.value;
-        if (selectedValue.startsWith('custom_')) {
-            deleteCustomTemplate(selectedValue);
-        }
-    });
-
-    UI_ELEMENTS.aiInstructions.addEventListener('change', (e) => {
-        chrome.storage.sync.set({ aiInstructions: e.target.value });
+        updateFilenamePreview();
     });
 
     UI_ELEMENTS.speakerAliasList.addEventListener('change', async (e) => {
@@ -517,7 +326,6 @@ function setupEventListeners() {
         }
     });
 
-    // Action Button Listeners
     UI_ELEMENTS.saveButton.addEventListener('click', async () => {
         const tab = await getActiveTeamsTab();
         if (tab) {
@@ -534,42 +342,6 @@ function setupEventListeners() {
 
     setupDropdown(UI_ELEMENTS.copyButton, UI_ELEMENTS.copyDropdownButton, UI_ELEMENTS.copyOptions, handleCopy);
     setupDropdown(null, UI_ELEMENTS.saveDropdownButton, UI_ELEMENTS.saveOptions, handleSave);
-
-    // AI Prompt Buttons - Now act as smart template selectors
-    UI_ELEMENTS.promptButtons.forEach(button => {
-        button.addEventListener('click', function() {
-            const buttonText = this.textContent;
-            let templateToSelect = '';
-            
-            // Map buttons to the most appropriate templates
-            switch(buttonText) {
-                case 'Summarize':
-                    templateToSelect = 'executive'; // Executive Summary template
-                    break;
-                case 'List Action Items':
-                    templateToSelect = 'retrospective'; // Has comprehensive action items
-                    break;
-                case 'Find Decisions':
-                    templateToSelect = 'review'; // Design Review has decision tracking
-                    break;
-            }
-            
-            // Select the template in dropdown
-            if (templateToSelect) {
-                UI_ELEMENTS.meetingType.value = templateToSelect;
-                // Trigger change event to load the template
-                UI_ELEMENTS.meetingType.dispatchEvent(new Event('change'));
-                
-                // Provide visual feedback
-                this.style.backgroundColor = '#28a745';
-                this.style.color = 'white';
-                setTimeout(() => {
-                    this.style.backgroundColor = '';
-                    this.style.color = '';
-                }, 500);
-            }
-        });
-    });
 
     document.addEventListener('click', () => {
         UI_ELEMENTS.copyOptions.style.display = 'none';
@@ -594,18 +366,17 @@ function setupDropdown(mainButton, dropdownButton, optionsContainer, actionHandl
 }
 
 async function handleCopy(target) {
-    const copyType = target.dataset.copyType;
-    if (!copyType) return;
+    if (!target.dataset.copyType) return;
 
     const tab = await getActiveTeamsTab();
     if (!tab) return;
-    
+
     UI_ELEMENTS.statusMessage.textContent = "Preparing text to copy...";
     try {
         const response = await chrome.tabs.sendMessage(tab.id, { message: "get_transcript_for_copying" });
         if (response?.transcriptArray) {
             const { speakerAliases = {} } = await chrome.storage.session.get('speakerAliases');
-            const formattedText = await formatTranscript(response.transcriptArray, speakerAliases, copyType);
+            const formattedText = await formatTranscript(response.transcriptArray, speakerAliases);
             await navigator.clipboard.writeText(formattedText);
             UI_ELEMENTS.statusMessage.textContent = "Copied to clipboard!";
             UI_ELEMENTS.statusMessage.style.color = '#28a745';
@@ -622,7 +393,7 @@ async function handleSave(target) {
     
     const tab = await getActiveTeamsTab();
     if (tab) {
-        UI_ELEMENTS.statusMessage.textContent = `Saving as ${format === 'ai' ? 'AI' : format.toUpperCase()}...`;
+        UI_ELEMENTS.statusMessage.textContent = `Saving as ${format.toUpperCase()}...`;
         chrome.tabs.sendMessage(tab.id, { message: "return_transcript", format });
     }
 }
@@ -847,7 +618,6 @@ function escapeHtml(text) {
 // --- Initialization ---
 async function initializePopup() {
     await loadSettings();
-    await loadCustomTemplates();
     setupEventListeners();
     await initializeSessionHistory(); // Initialize session history
 


### PR DESCRIPTION
## Summary
- Refresh the popup layout for a PWA-friendly footprint and limit copy/save options to TXT or Markdown.
- Remove AI-specific settings, add a filename preview, and simplify event handling in the popup logic.
- Normalize exports and timestamps in the background scripts and document the lean workflow in the README.

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68dd3e1c1bb08320a10e210769b77fb0