### PR TITLE
Normalize ErrorHandler logs and downgrade no-receiver runtime errors

### DIFF
--- a/teams-captions-saver/content_script.js
+++ b/teams-captions-saver/content_script.js
@@ -137,17 +137,50 @@ function broadcastAttendeeUpdate(data) {
 
 // --- Error Handling & Logging ---
 class ErrorHandler {
+    static getErrorMessage(error) {
+        if (typeof error === 'string') {
+            return error;
+        }
+
+        if (error && typeof error.message === 'string' && error.message.trim().length > 0) {
+            return error.message;
+        }
+
+        if (error && typeof error === 'object') {
+            try {
+                return JSON.stringify(error);
+            } catch (_stringifyError) {
+                return String(error);
+            }
+        }
+
+        return String(error);
+    }
+
+    static isNoReceiverError(message) {
+        return typeof message === 'string' && (
+            message.includes('Receiving end does not exist')
+            || message.includes('Could not establish connection')
+            || message.includes('The message port closed before a response was received')
+        );
+    }
+
     static log(error, context = '', silent = false) {
         const timestamp = new Date().toISOString();
+        const message = ErrorHandler.getErrorMessage(error);
         const errorInfo = {
             timestamp,
             context,
-            message: error.message || String(error),
+            message,
             stack: error.stack,
             url: window.location.href
         };
-        
-        console.error(`[Teams Caption Saver] ${context}:`, errorInfo);
+
+        if (ErrorHandler.isNoReceiverError(message)) {
+            console.warn(`[Teams Caption Saver] ${context}: ${message}`);
+        } else {
+            console.error(`[Teams Caption Saver] ${context}: ${message}`, errorInfo);
+        }
         
         if (!silent) {
             // Could send to analytics or show user notification


### PR DESCRIPTION
### Motivation
- Reduce noisy console entries and extension "Issues" caused by logging raw error objects (e.g. `[object Object]`) and treat expected runtime message-port failures (no listener) as warnings instead of errors.

### Description
- In `teams-captions-saver/content_script.js` added `ErrorHandler.getErrorMessage` and `ErrorHandler.isNoReceiverError`, and updated `ErrorHandler.log` to normalize unknown error values into readable strings and downgrade common Chrome runtime "no receiver" messages to `console.warn` while preserving existing `chrome.runtime.sendMessage({ message: 'error_logged', ... })` behavior.

### Testing
- Ran `npm run lint` (which executes `node scripts/check-extension.mjs`) and extension validation passed; `npm test` was attempted but failed because no `test` script is defined in `package.json`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a5c7d34f588320b9e4a8711273befa)